### PR TITLE
feature/attach payment methods and confirm intents

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "The MIT License"
             :url  "https://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.9.0"]
-                 [com.stripe/stripe-java "10.12.1"]]
+                 [com.stripe/stripe-java "19.12.0"]]
   :plugins [[jonase/eastwood "0.2.5"]
             [lein-eftest "0.5.3"]
             [lein-changelog "0.3.2"]

--- a/src/zebra/charges.clj
+++ b/src/zebra/charges.clj
@@ -9,7 +9,7 @@
                    :pending   "pending"
                    :failed    "failed"})
 
-(defn charge->map [charge]
+(defn charge->map [^Charge charge]
   {:id     (.getId charge)
    :status (.getStatus charge)})
 

--- a/src/zebra/core.clj
+++ b/src/zebra/core.clj
@@ -30,6 +30,9 @@
 (defn attach-source-to-customer [customer-id source-id api-key]
   (customers/attach-source customer-id source-id api-key))
 
+(defn attach-payment-method-to-customer [customer-id payment-method-id api-key]
+  (customers/attach-payment-method customer-id payment-method-id api-key))
+
 ;Sources
 
 (defn create-source [params api-key]

--- a/src/zebra/core.clj
+++ b/src/zebra/core.clj
@@ -71,3 +71,6 @@
 
 (defn capture-payment-intent [id api-key]
   (payment-intents/capture id api-key))
+
+(defn confirm-payment-intent [id api-key]
+  (payment-intents/confirm id api-key))

--- a/src/zebra/customers.clj
+++ b/src/zebra/customers.clj
@@ -1,7 +1,8 @@
 (ns zebra.customers
   (:refer-clojure :exclude [list update])
-  (:require [zebra.sources :refer [source->map]])
-  (:import [com.stripe.model Customer]
+  (:require [zebra.sources :refer [source->map]]
+            [zebra.payment-methods :refer [payment-method->map]])
+  (:import [com.stripe.model Customer PaymentMethod]
            [com.stripe.net RequestOptions]
            [java.util Map]))
 
@@ -35,3 +36,10 @@
     (source->map
       (.create sources {"source" source-id}
         (-> (RequestOptions/builder) (.setApiKey api-key) .build)))))
+
+(defn attach-payment-method
+  [customer-id payment-method-id api-key]
+  (let [^RequestOptions request (-> (RequestOptions/builder) (.setApiKey api-key) .build)
+        pm (PaymentMethod/retrieve payment-method-id request)]
+    (payment-method->map
+      (.attach pm {"customer" customer-id} request))))

--- a/src/zebra/customers.clj
+++ b/src/zebra/customers.clj
@@ -5,7 +5,7 @@
            [com.stripe.net RequestOptions]
            [java.util Map]))
 
-(defn customer->map [customer]
+(defn customer->map [^Customer customer]
   {:id       (.getId customer)
    :metadata (.getMetadata customer)
    :sources  (.getSources customer)})

--- a/src/zebra/payment_intents.clj
+++ b/src/zebra/payment_intents.clj
@@ -55,3 +55,10 @@
         payment-intent
         (PaymentIntent/retrieve id opts)]
     (payment-intent->map (.capture payment-intent opts))))
+
+(defn confirm
+  [id api-key]
+  (let [opts (-> (RequestOptions/builder) (.setApiKey api-key) .build)
+        payment-intent (PaymentIntent/retrieve id opts)]
+    (payment-intent->map
+      (.confirm payment-intent {} opts))))

--- a/src/zebra/payment_intents.clj
+++ b/src/zebra/payment_intents.clj
@@ -13,7 +13,7 @@
       {:redirect_to_url {:return_url (.getReturnUrl redirect-to-url)
                          :url        (.getUrl redirect-to-url)}})))
 
-(defn payment-intent->map [x]
+(defn payment-intent->map [^PaymentIntent x]
   (merge
     {:id                   (.getId x)
      :object               (.getObject x)

--- a/src/zebra/payment_methods.clj
+++ b/src/zebra/payment_methods.clj
@@ -6,18 +6,19 @@
            [java.util Map]))
 
 (defn payment-method->map [^PaymentMethod x]
-  (merge
-    {:id     (.getId x)
-     :object (.getObject x)}
-    (when-let [card (.getCard x)]
-      {:card {:brand     (.getBrand card)
-              :exp_month (.getExpMonth card)
-              :exp_year  (.getExpYear card)
-              :funding   (.getFunding card)
-              :last4     (.getLast4 card)
-              :three_d_secure_usage
-                         {:supported
-                          (-> card .getThreeDSecureUsage .getSupported)}}})))
+  (with-meta (merge
+               {:id     (.getId x)
+                :object (.getObject x)}
+               (when-let [card (.getCard x)]
+                 {:card {:brand     (.getBrand card)
+                         :exp_month (.getExpMonth card)
+                         :exp_year  (.getExpYear card)
+                         :funding   (.getFunding card)
+                         :last4     (.getLast4 card)
+                         :three_d_secure_usage
+                                    {:supported
+                                     (-> card .getThreeDSecureUsage .getSupported)}}}))
+             {:original x}))
 
 (defn create
   [params api-key]

--- a/src/zebra/payment_methods.clj
+++ b/src/zebra/payment_methods.clj
@@ -5,7 +5,7 @@
            [com.stripe.net RequestOptions]
            [java.util Map]))
 
-(defn payment-method->map [x]
+(defn payment-method->map [^PaymentMethod x]
   (merge
     {:id     (.getId x)
      :object (.getObject x)}

--- a/src/zebra/sources.clj
+++ b/src/zebra/sources.clj
@@ -33,7 +33,7 @@
    :three_d_secure      (.getThreeDSecure card)
    :tokenization_method (.getTokenizationMethod card)})
 
-(defn source->map [source]
+(defn source->map [^Source source]
   (merge
     {:id       (.getId source)
      :customer (.getCustomer source)

--- a/test/zebra/payment_intents_test.clj
+++ b/test/zebra/payment_intents_test.clj
@@ -61,8 +61,8 @@
                           :confirm              true
                           :confirmation_method  "automatic"
                           :payment_method       (:id payment-method)
-                          :return_url           "http://www.google.com"
-                          }
+                          :return_url           "http://www.google.com"}
+
                          api-key)]
 
     (testing "should create a valid payment intent"
@@ -131,3 +131,26 @@
 
     (testing "should have captured"
       (is (= "succeeded" (:status payment-intent2))))))
+
+(deftest confirm-payment-intent
+  (let [payment-method (payment-methods/create
+                         {:type "card"
+                          :card {:number    "4242424242424242"
+                                 :exp_month "7"
+                                 :exp_year  "2020"
+                                 :cvc       "314"}} api-key)
+        payment-intent (payment-intent/create
+                         {:amount               1234
+                          :currency             "gbp"
+                          :payment_method_types ["card"]
+                          :confirmation_method  "automatic"
+                          :payment_method       (:id payment-method)}
+                         api-key)
+        confirmed-intent (payment-intent/confirm (:id payment-intent) api-key)]
+    (is (= (:status payment-intent "requires_confirmation"))
+        "Intent has not yet been confirmed")
+    (is (= (:id confirmed-intent)
+           (:id payment-intent))
+        "Confirmed intent and pending intent have same id")
+    (is (= (:status confirmed-intent) "succeeded")
+        "Confirming the intent has caused it to succeed")))


### PR DESCRIPTION
I've backported a few operations from a project that uses zebra into this PR, and taken the opportunity to look at some patterns that might be helpful that came up while doing the work. 

- fixed some reflection warnings
- add `attach-payment-method-to-customer`
- add `confirm-payment-intent`
- bumped stripe-java to `19.12.0`

In the process of writing tests for adding the payment method attach function, I found myself wanting access to the original backing object before it gets turned into a map. I've added something inspired by [cognitect's aws library](https://github.com/cognitect-labs/aws-api#explore) where they added the original http request as metadata. Metadata doesn't take part in the identity calculation of the value, so it's safe to have it there and still retain equality semantics. 

If you like this, let me know, and can apply it to other transforming functions. If not, will rework this test, maybe by adding something like..

```clj
:customer (.getCustomer x)
```

to the `payment-method->map` fn.

```
➜  zebra git:(master) ✗ lein test

lein test zebra.charges-test

lein test zebra.customers-test

lein test zebra.ephemeral-keys-test

lein test zebra.helpers.constants

lein test zebra.payment-intents-test

lein test zebra.payment-methods-test

lein test zebra.sources-test

Ran 22 tests containing 63 assertions.
0 failures, 0 errors.
```